### PR TITLE
Update build_tarballs.jl

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -33,7 +33,7 @@ fi
 
 # Build for ALL THE PLATFORMS!
 platforms = supported_platforms()
-platforms = expand_gcc_versions(platforms)
+#platforms = expand_gcc_versions(platforms)
 
 # The products that we will ensure are always built
 products = prefix -> [


### PR DESCRIPTION
build with new binarybuilder is allegedly enough to fix the memcopy@glibc2.14 issue